### PR TITLE
DFS support in the library

### DIFF
--- a/internal/smb2/const.go
+++ b/internal/smb2/const.go
@@ -7,6 +7,12 @@ const (
 	MAGIC2 = "\xfdSMB"
 )
 
+var (
+	// When the IOCTL code is FSCTL_DFS_GET_REFERRALS or FSCTL_DFS_GET_REFERRALS_EX
+	// client should send the FileID 0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF
+	DFSFileID = [8]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+)
+
 // ----------------------------------------------------------------------------
 // SMB2 Packet Header
 //


### PR DESCRIPTION
This PR implements the DFS requests & responses via IOCTL call where we have handled multiple referral entries. Please note that DFS requests are invoked on IPC$. 

This enabled us to invoke the Readdir, and other RPC calls using DFS.

TODO: In the DFS request, if the NAS device is Windows DFS, for converting dirname in the request, we need to append one extra space. If not done, the response is not formed properly. This is not required for DFS based on Nutanix setups. I am not sure why this behavior and need inputs to understand. 

Below is the code snippet for the 
	dfsRefReq := DFSReferralRequest{
		MaxReferralLevel: 4,
		RequestFileName:  fmt.Sprintf("%s ", dfsname), // Note this is the tweak for Windows DFS vs Nutanix DFS
		//RequestFileName:  fmt.Sprintf("%s", dfsname), // Note this will work with Non Windows DFS
	}

Kindly refer to the example and let me know if any changes are necessary!
